### PR TITLE
Better support of zero count read without EOF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format: format-deps
 
 .PHONY: test
 test:
-	$(call squote,$(GO)) test -C $(call squote,$(MAKEFILE_DIR)) ./...
+	$(call squote,$(GO)) test -C $(call squote,$(MAKEFILE_DIR)) -cover ./...
 
 .PHONY: build
 build:

--- a/cmd/fcmp/main.go
+++ b/cmd/fcmp/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: go run main.go <file1> <file2>")
+		fmt.Println("Usage: fcmp <file1> <file2>")
 		os.Exit(1)
 	}
 	name1 := os.Args[1]

--- a/cmd/fcmp/main.go
+++ b/cmd/fcmp/main.go
@@ -26,7 +26,7 @@ func main() {
 		os.Exit(2)
 	}
 	defer func() { _ = f2.Close() }()
-	eq, err := cmp.EqualReaders(4096, f1, f2)
+	eq, err := cmp.EqualReaders(4096, 2, f1, f2)
 	if err != nil {
 		fmt.Printf("Failed to compare files: %v\n", err)
 		os.Exit(2)

--- a/cmp/cmp.go
+++ b/cmp/cmp.go
@@ -6,89 +6,86 @@ import (
 	"io"
 )
 
-func EqualReaders(bufSize int, maxZeroReads int, r1 io.Reader, r2 io.Reader) (bool, error) {
+func EqualReaders(bufSize int, maxZeroCountReads int, r1 io.Reader, r2 io.Reader) (bool, error) {
 	if bufSize <= 0 {
 		return false, errors.New("bufSize must be greater than zero")
 	}
 
 	var (
-		filledStart1, filledEnd1, totalRead1 int
-		filledStart2, filledEnd2, totalRead2 int
-		zeroRead1, zeroRead2                 = maxZeroReads, maxZeroReads
-		eof1, eof2                           bool
-		buf1, buf2                           = make([]byte, bufSize), make([]byte, bufSize)
-		err                                  error
+		filled1, free1, size1 int
+		filled2, free2, size2 int
+		zero1, zero2          = maxZeroCountReads, maxZeroCountReads
+		eof1, eof2            bool
+		buf1, buf2            = make([]byte, bufSize), make([]byte, bufSize)
 	)
 
-	for {
+	for !eof1 || !eof2 {
+		if eof1 && size1 < size2 || eof2 && size2 < size1 {
+			return false, nil
+		}
+
 		read1 := 0
-		if !eof1 && filledEnd1 < bufSize {
-			notFilledEnd := bufSize
-			if eof2 && totalRead1 <= totalRead2 {
-				maxRead := totalRead2 - totalRead1 + 1
-				notFilledEnd = min(notFilledEnd, filledEnd1+maxRead)
-			}
-			read1, err = r1.Read(buf1[filledEnd1:notFilledEnd])
+		if !eof1 && free1 < bufSize {
+			readEnd := getReadEnd(bufSize, free1, size1, size2, eof2)
+			var err error
+			read1, err = r1.Read(buf1[free1:readEnd])
 			eof1 = errors.Is(err, io.EOF)
 			if err != nil && !eof1 {
 				return false, err
 			}
-			if !eof1 && notFilledEnd-filledEnd1 > 0 && read1 == 0 {
-				if zeroRead1 <= 0 {
+			if read1 == 0 && !eof1 && readEnd-free1 > 0 {
+				if zero1 <= 0 {
 					return false, errors.New("too many reads of zero byte count without EOF in r1")
 				}
-				zeroRead1--
+				zero1--
 			}
-			totalRead1 += read1
+			size1 += read1
 		}
 
 		read2 := 0
-		if !eof2 && filledEnd2 < bufSize {
-			readEnd := bufSize
-			if eof1 && totalRead2 <= totalRead1 {
-				maxRead := totalRead1 - totalRead2 + 1
-				readEnd = min(readEnd, filledEnd2+maxRead)
-			}
-			read2, err = r2.Read(buf2[filledEnd2:readEnd])
+		if !eof2 && free2 < bufSize {
+			readEnd := getReadEnd(bufSize, free2, size2, size1, eof1)
+			var err error
+			read2, err = r2.Read(buf2[free2:readEnd])
 			eof2 = errors.Is(err, io.EOF)
 			if err != nil && !eof2 {
 				return false, err
 			}
-			if !eof2 && readEnd-filledEnd2 > 0 && read2 == 0 {
-				if zeroRead2 <= 0 {
+			if read2 == 0 && !eof2 && readEnd-free2 > 0 {
+				if zero2 <= 0 {
 					return false, errors.New("too many reads of zero byte count without EOF in r2")
 				}
-				zeroRead2--
+				zero2--
 			}
-			totalRead2 += read2
+			size2 += read2
 		}
 
-		commonFilled := min(filledEnd1-filledStart1+read1, filledEnd2-filledStart2+read2)
-		if !bytes.Equal(buf1[filledStart1:filledStart1+commonFilled], buf2[filledStart2:filledStart2+commonFilled]) {
+		size := min(size1, size2)
+		if !bytes.Equal(buf1[filled1:filled1+size], buf2[filled2:filled2+size]) {
 			return false, nil
 		}
 
-		filledStart1, filledEnd1 = shift(filledStart1, filledEnd1, commonFilled, read1)
-		filledStart2, filledEnd2 = shift(filledStart2, filledEnd2, commonFilled, read2)
-
-		if eof1 && eof2 {
-			break
-		}
-		if eof1 && totalRead1 < totalRead2 {
-			return false, nil
-		}
-		if eof2 && totalRead2 < totalRead1 {
-			return false, nil
-		}
+		filled1, free1 = shiftBounds(filled1, size, free1, read1)
+		filled2, free2 = shiftBounds(filled2, size, free2, read2)
+		size1 -= size
+		size2 -= size
 	}
-	return filledEnd1-filledStart1 == 0 && filledEnd2-filledStart2 == 0, nil
+	return size1 == 0 && size2 == 0, nil
 }
 
-func shift(filledBegin, filledEnd, beginOffset, endOffset int) (int, int) {
-	filledBegin += beginOffset
-	filledEnd += endOffset
-	if filledBegin == filledEnd {
+func getReadEnd(bufSize int, free1 int, size1 int, size2 int, eof2 bool) int {
+	if eof2 && size1 <= size2 {
+		maxRead := size2 - size1 + 1
+		return min(bufSize, free1+maxRead)
+	}
+	return bufSize
+}
+
+func shiftBounds(filled, filledOffset, free, freeOffset int) (int, int) {
+	filled += filledOffset
+	free += freeOffset
+	if filled == free {
 		return 0, 0
 	}
-	return filledBegin, filledEnd
+	return filled, free
 }

--- a/cmp/cmp_test.go
+++ b/cmp/cmp_test.go
@@ -1,27 +1,25 @@
 package cmp
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"math/rand/v2"
 	"testing"
 )
 
-func TestEqualReadersWithRandomChunks(t *testing.T) {
-	const size = 100
-	reader1 := newRandomChunkReader(size)
-	reader2 := newRandomChunkReader(size)
-	eq, err := EqualReaders(10, 0, reader1, reader2)
-	if err != nil {
-		t.Fatal("unexpected error:", err)
-	}
-	if !eq {
-		t.Fatal("expected equal readers")
+func TestWrongBufSize(t *testing.T) {
+	reader1 := bytes.NewReader(make([]byte, 0))
+	reader2 := bytes.NewReader(make([]byte, 0))
+	_, err := EqualReaders(0, 0, reader1, reader2)
+	if err == nil {
+		t.Fatal("expected error due to wrong buffer size")
 	}
 }
 
-func TestNotEqualReadersWithRandomChunks(t *testing.T) {
-	reader1 := newRandomChunkReader(100)
-	reader2 := newRandomChunkReader(120)
+func TestDifferentReaders(t *testing.T) {
+	reader1 := bytes.NewReader(append(newIncrementArray(10), newIncrementArray(100)...))
+	reader2 := bytes.NewReader(append(newIncrementArray(10), newDecrementArray(100)...))
 	eq, err := EqualReaders(10, 0, reader1, reader2)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
@@ -31,17 +29,109 @@ func TestNotEqualReadersWithRandomChunks(t *testing.T) {
 	}
 }
 
+func TestEqualReadersWithRandomChunks(t *testing.T) {
+	const size = 100
+	reader1 := &randomChunkReader{data: newIncrementArray(size)}
+	reader2 := &randomChunkReader{data: newIncrementArray(size)}
+	eq, err := EqualReaders(10, 0, reader1, reader2)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if !eq {
+		t.Fatal("expected equal readers")
+	}
+}
+
+func TestDifferentReadersWithRandomChunks(t *testing.T) {
+	reader1 := &randomChunkReader{data: newIncrementArray(100)}
+	reader2 := &randomChunkReader{data: newIncrementArray(120)}
+	eq, err := EqualReaders(10, 0, reader1, reader2)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if eq {
+		t.Fatal("expected not equal readers")
+	}
+}
+
+func TestEOFWithoutZeroCountRead(t *testing.T) {
+	reader1 := &immediateEOFReader{data: newIncrementArray(100)}
+	reader2 := &immediateEOFReader{data: newIncrementArray(100)}
+	eq, err := EqualReaders(200, 0, reader1, reader2)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if !eq {
+		t.Fatal("expected equal readers")
+	}
+}
+
+func TestMaxZeroCountReadWithoutEOF1(t *testing.T) {
+	reader1 := &zeroByteCountReader{data: newIncrementArray(100)}
+	reader2 := &zeroByteCountReader{data: newIncrementArray(200)}
+	_, err := EqualReaders(10, 2, reader1, reader2)
+	if err == nil {
+		t.Fatal("expected error due to too many zero byte count reads without EOF at reader1")
+	}
+}
+
+func TestMaxZeroCountReadWithoutEOF2(t *testing.T) {
+	reader1 := &zeroByteCountReader{data: newIncrementArray(200)}
+	reader2 := &zeroByteCountReader{data: newIncrementArray(100)}
+	_, err := EqualReaders(10, 2, reader1, reader2)
+	if err == nil {
+		t.Fatal("expected error due to too many zero byte count reads without EOF at reader2")
+	}
+}
+
+func TestErrorRead1(t *testing.T) {
+	var reader1 errorReader
+	reader2 := bytes.NewReader(newDecrementArray(100))
+	_, err := EqualReaders(10, 2, reader1, reader2)
+	if err == nil {
+		t.Fatal("expected error due to read from reader1 returned error")
+	}
+}
+
+func TestErrorRead2(t *testing.T) {
+	reader1 := bytes.NewReader(newDecrementArray(100))
+	var reader2 errorReader
+	_, err := EqualReaders(10, 2, reader1, reader2)
+	if err == nil {
+		t.Fatal("expected error due to read from reader2 returned error")
+	}
+}
+
+func newIncrementArray(size int) []byte {
+	s := make([]byte, 0, size)
+	for i := 0; i < size; i++ {
+		s = append(s, byte(i))
+	}
+	return s
+}
+
+func newDecrementArray(size int) []byte {
+	s := make([]byte, 0, size)
+	for i, n := 0, size; i < size; i++ {
+		s = append(s, byte(n))
+		n--
+	}
+	return s
+}
+
 type randomChunkReader struct {
 	data []byte
 }
 
-func newRandomChunkReader(size int) *randomChunkReader {
-	r := &randomChunkReader{data: make([]byte, 0, size)}
-	for i := 0; i < size; i++ {
-		r.data = append(r.data, byte(i))
-	}
-	return r
+type immediateEOFReader struct {
+	data []byte
 }
+
+type zeroByteCountReader struct {
+	data []byte
+}
+
+type errorReader struct{}
 
 func (reader *randomChunkReader) Read(buf []byte) (n int, err error) {
 	if len(reader.data) == 0 {
@@ -52,4 +142,31 @@ func (reader *randomChunkReader) Read(buf []byte) (n int, err error) {
 	copy(buf, reader.data[:n])
 	reader.data = reader.data[n:]
 	return
+}
+
+func (reader *immediateEOFReader) Read(buf []byte) (n int, err error) {
+	if len(reader.data) == 0 {
+		return 0, io.EOF
+	}
+	n = min(len(buf), len(reader.data))
+	copy(buf, reader.data[:n])
+	reader.data = reader.data[n:]
+	if len(reader.data) == 0 {
+		err = io.EOF
+	}
+	return
+}
+
+func (reader *zeroByteCountReader) Read(buf []byte) (n int, err error) {
+	if len(reader.data) == 0 {
+		return 0, nil
+	}
+	n = min(len(buf), len(reader.data))
+	copy(buf, reader.data[:n])
+	reader.data = reader.data[n:]
+	return
+}
+
+func (errorReader) Read([]byte) (n int, err error) {
+	return 0, errors.New("test terror")
 }

--- a/cmp/cmp_test.go
+++ b/cmp/cmp_test.go
@@ -10,7 +10,7 @@ func TestEqualReadersWithRandomChunks(t *testing.T) {
 	const size = 100
 	reader1 := newRandomChunkReader(size)
 	reader2 := newRandomChunkReader(size)
-	eq, err := EqualReaders(10, reader1, reader2)
+	eq, err := EqualReaders(10, 0, reader1, reader2)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -22,7 +22,7 @@ func TestEqualReadersWithRandomChunks(t *testing.T) {
 func TestNotEqualReadersWithRandomChunks(t *testing.T) {
 	reader1 := newRandomChunkReader(100)
 	reader2 := newRandomChunkReader(120)
-	eq, err := EqualReaders(10, reader1, reader2)
+	eq, err := EqualReaders(10, 0, reader1, reader2)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}


### PR DESCRIPTION
Notes:

1. Refer to https://pkg.go.dev/io#Reader.Read:
    > ... a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil. The next Read should return 0, EOF.
    >
    > Implementations of Read are discouraged from returning a zero byte count with a nil error, except when len(p) == 0. Callers should treat a return of 0 and nil as indicating that nothing happened; in particular it does not indicate EOF.

Changes:

* Configurable limit for zero byte count read without EOF to avoid infinite loop.
* Refactoring.
* Tests for 100% line coverage.